### PR TITLE
Create types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/vue-media-queries.js",
   "module": "dist/vue-media-queries.mjs",
   "jsnext:main": "dist/vue-media-queries.mjs",
+  "types" : "src/index.d.ts",
   "keywords": [
     "vue",
     "mediaqueries",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,27 @@
+import Vue, { VueConstructor, ComponentOptions, PluginFunction } from 'vue'
+import { default as bands } from '../src/bands'
+
+export declare interface MediaQueryBands {
+    mixin: ComponentOptions<Vue>
+    [key: string]: any
+}
+
+export declare class MediaQueries {
+    constructor(options?: { bands: MediaQueryBands })
+    expr(expressionString): boolean
+    below(...args): boolean
+    above(...args): boolean
+    between(...args): boolean
+    beyond(...args): boolean
+    install(Vue): PluginFunction<VueConstructor>
+}
+
+export declare type CommonBands<T, K extends keyof bands> = {
+    [K in keyof T]: MediaQueryBands
+}
+
+declare module 'vue/types/vue' {
+    interface Vue {
+        readonly $mq: MediaQueries
+    }
+}


### PR DESCRIPTION
I've been trying to get the following working so that the appropriate computed properties (i.e. `isLgDown`) will show up when autocompleting inside a Vue component:

```js
Vue.mixin(CommonBands.Bootstrap4.mixin)
```

Not sure if it's just because `Vue.mixin` only recognizes object literals or what.

Regardless, some basic typing here should at least help get this started.